### PR TITLE
Add readlog feature

### DIFF
--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import sys
 
 from . import __version__
 
@@ -15,6 +16,10 @@ def parse_args(args=None):
         "--logfile",
         help="Yazılacak log dosyasının yolu"
     )
+    parser.add_argument(
+        "--readlog",
+        help="Okunacak log dosyasının yolu"
+    )
     return parser.parse_args(args)
 
 
@@ -22,6 +27,15 @@ def main(argv=None):
     args = parse_args(argv)
     if args.logfile:
         logging.basicConfig(filename=args.logfile, level=logging.INFO)
+    if args.readlog:
+        try:
+            with open(args.readlog, encoding="utf-8") as f:
+                for line in f:
+                    if "ERROR" in line:
+                        print(line.rstrip("\n"))
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {args.readlog}", file=sys.stderr)
+            sys.exit(1)
     logging.info("KarSec started")
 
 

--- a/logs/ornek.log
+++ b/logs/ornek.log
@@ -1,0 +1,4 @@
+Info line 1
+ERROR first issue
+Some info
+ERROR second issue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,12 +7,17 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pytest
 
 from karsec import __version__
-from karsec.cli import parse_args
+from karsec.cli import parse_args, main
 
 
 def test_parse_logfile():
     args = parse_args(["--logfile", "test.log"])
     assert args.logfile == "test.log"
+
+
+def test_parse_readlog():
+    args = parse_args(["--readlog", "example.log"])
+    assert args.readlog == "example.log"
 
 
 def test_version_option(capsys):
@@ -31,5 +36,22 @@ def test_cli_version_subprocess():
     )
     assert result.stdout.strip() == f"karsec {__version__}"
     assert result.returncode == 0
+
+
+def test_readlog_output(capsys):
+    log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "logs", "ornek.log"))
+    main(["--readlog", log_path])
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.strip().splitlines() if line]
+    assert len(lines) == 2
+    assert all("ERROR" in line for line in lines)
+
+
+def test_readlog_file_not_found(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--readlog", "nonexistent.log"])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Dosya bulunamadi" in captured.err
 
 


### PR DESCRIPTION
## Summary
- allow reading log files with `--readlog`
- list error lines from the given file or report missing file
- add sample log file
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ce3a533c83218d51e41a60e0ec8e