### PR TITLE
Add log summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--logfile`: Belirtilen dosyaya log kaydı başlatır
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
+- `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 
 ## Kurulum
 ```bash
@@ -18,6 +19,7 @@ karsec --version
 karsec --logfile logs/test.log
 karsec --readlog logs/test.log
 karsec --detect-ddos logs/ddos.log
+karsec --summary logs/test.log
 Test nasıl yapılır?
 pytest tests/
 

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -26,6 +26,10 @@ def parse_args(args=None):
         "--detect-ddos",
         help="DDoS tespiti yapilacak log dosyasi"
     )
+    parser.add_argument(
+        "--summary",
+        help="Log dosyasindaki INFO, WARNING ve ERROR sayilarini ozetler"
+    )
     return parser.parse_args(args)
 
 
@@ -65,6 +69,24 @@ def main(argv=None):
         for ip, count in counts.items():
             if count > 100:
                 print(f"DDoS \u015f\u00fcpheli IP: {ip} - {count}")
+    if args.summary:
+        summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
+        try:
+            with open(args.summary, encoding="utf-8") as f:
+                for line in f:
+                    upper = line.upper()
+                    if "INFO" in upper:
+                        summary_counts["INFO"] += 1
+                    if "WARNING" in upper:
+                        summary_counts["WARNING"] += 1
+                    if "ERROR" in upper:
+                        summary_counts["ERROR"] += 1
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {args.summary}", file=sys.stderr)
+            sys.exit(1)
+        print(
+            f"INFO: {summary_counts['INFO']} WARNING: {summary_counts['WARNING']} ERROR: {summary_counts['ERROR']}"
+        )
     logging.info("KarSec started")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,11 @@ def test_parse_detect_ddos():
     assert args.detect_ddos == "ddos.log"
 
 
+def test_parse_summary():
+    args = parse_args(["--summary", "some.log"])
+    assert args.summary == "some.log"
+
+
 def test_version_option(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_args(["--version"])
@@ -56,6 +61,24 @@ def test_readlog_output(capsys):
 def test_readlog_file_not_found(capsys):
     with pytest.raises(SystemExit) as exc:
         main(["--readlog", "nonexistent.log"])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Dosya bulunamadi" in captured.err
+
+
+def test_summary_output(capsys, tmp_path):
+    log_file = tmp_path / "summary.log"
+    log_file.write_text("""INFO start\nWARNING watch\nERROR fail\nINFO end\n""", encoding="utf-8")
+    main(["--summary", str(log_file)])
+    captured = capsys.readouterr()
+    assert "INFO: 2" in captured.out
+    assert "WARNING: 1" in captured.out
+    assert "ERROR: 1" in captured.out
+
+
+def test_summary_file_not_found(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--summary", "missing.log"])
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "Dosya bulunamadi" in captured.err


### PR DESCRIPTION
## Summary
- add `--summary` option to CLI for INFO/WARNING/ERROR counts
- document the new option in README
- test CLI summary parsing and behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d91687c883218108c6fd546dde3b