### PR TITLE
Add scan-alert CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
+- `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 
 ## Kurulum
 ```bash
@@ -20,6 +21,7 @@ karsec --logfile logs/test.log
 karsec --readlog logs/test.log
 karsec --detect-ddos logs/ddos.log
 karsec --summary logs/test.log
+karsec --scan-alert logs/test.log
 Test nasıl yapılır?
 pytest tests/
 

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -30,6 +30,10 @@ def parse_args(args=None):
         "--summary",
         help="Log dosyasindaki INFO, WARNING ve ERROR sayilarini ozetler"
     )
+    parser.add_argument(
+        "--scan-alert",
+        help="Log dosyasinda nmap, masscan veya nikto iceren satirlari goster"
+    )
     return parser.parse_args(args)
 
 
@@ -69,6 +73,17 @@ def main(argv=None):
         for ip, count in counts.items():
             if count > 100:
                 print(f"DDoS \u015f\u00fcpheli IP: {ip} - {count}")
+    if args.scan_alert:
+        keywords = ("nmap", "masscan", "nikto")
+        try:
+            with open(args.scan_alert, encoding="utf-8") as f:
+                for lineno, line in enumerate(f, 1):
+                    lower = line.lower()
+                    if any(keyword in lower for keyword in keywords):
+                        print(f"{lineno}: {line.rstrip('\n')}")
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {args.scan_alert}", file=sys.stderr)
+            sys.exit(1)
     if args.summary:
         summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,3 +98,26 @@ def test_detect_ddos_output(capsys):
     assert "DDoS" in captured.out
 
 
+def test_parse_scan_alert():
+    args = parse_args(["--scan-alert", "scan.log"])
+    assert args.scan_alert == "scan.log"
+
+
+def test_scan_alert_output(capsys, tmp_path):
+    log_file = tmp_path / "scan.log"
+    log_file.write_text("Nmap taramasi\nNormal satir\nnikto test\n", encoding="utf-8")
+    main(["--scan-alert", str(log_file)])
+    captured = capsys.readouterr()
+    out_lines = captured.out.strip().splitlines()
+    assert any("1: Nmap taramasi" in line for line in out_lines)
+    assert any("3: nikto test" in line for line in out_lines)
+
+
+def test_scan_alert_file_not_found(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--scan-alert", "yok.log"])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Dosya bulunamadi" in captured.err
+
+


### PR DESCRIPTION
## Summary
- add `--scan-alert` option to CLI to report potential scans
- update README with usage example
- test scan alert feature and error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844dba387488321a0b70ce20f7a3941