### PR TITLE
Add graph-summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
+- `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak gösterir
 
 ## Kurulum
 ```bash

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -34,6 +34,10 @@ def parse_args(args=None):
         "--scan-alert",
         help="Log dosyasinda nmap, masscan veya nikto iceren satirlari goster"
     )
+    parser.add_argument(
+        "--graph-summary",
+        help="Log dosyasindaki INFO, WARNING ve ERROR sayilarini grafik olarak goster"
+    )
     return parser.parse_args(args)
 
 
@@ -84,6 +88,35 @@ def main(argv=None):
         except FileNotFoundError:
             print(f"Dosya bulunamadi: {args.scan_alert}", file=sys.stderr)
             sys.exit(1)
+    if args.graph_summary:
+        summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
+        try:
+            with open(args.graph_summary, encoding="utf-8") as f:
+                for line in f:
+                    upper = line.upper()
+                    if "INFO" in upper:
+                        summary_counts["INFO"] += 1
+                    if "WARNING" in upper:
+                        summary_counts["WARNING"] += 1
+                    if "ERROR" in upper:
+                        summary_counts["ERROR"] += 1
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {args.graph_summary}", file=sys.stderr)
+            sys.exit(1)
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        labels = ["INFO", "WARNING", "ERROR"]
+        values = [summary_counts[l] for l in labels]
+        colors = ["blue", "orange", "red"]
+
+        plt.bar(labels, values, color=colors)
+        plt.title("Log Ozeti")
+        plt.xlabel("Seviye")
+        plt.ylabel("Adet")
+        plt.tight_layout()
+        plt.show()
     if args.summary:
         summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
         try:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pyfiglet',
+        'matplotlib',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,11 @@ def test_parse_summary():
     assert args.summary == "some.log"
 
 
+def test_parse_graph_summary():
+    args = parse_args(["--graph-summary", "some.log"])
+    assert args.graph_summary == "some.log"
+
+
 def test_version_option(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_args(["--version"])
@@ -79,6 +84,22 @@ def test_summary_output(capsys, tmp_path):
 def test_summary_file_not_found(capsys):
     with pytest.raises(SystemExit) as exc:
         main(["--summary", "missing.log"])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Dosya bulunamadi" in captured.err
+
+
+def test_graph_summary_output(capsys, tmp_path):
+    log_file = tmp_path / "graph.log"
+    log_file.write_text("INFO x\nWARNING y\nERROR z\nINFO a\n", encoding="utf-8")
+    main(["--graph-summary", str(log_file)])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_graph_summary_file_not_found(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--graph-summary", "yok.log"])
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "Dosya bulunamadi" in captured.err


### PR DESCRIPTION
## Summary
- add `--graph-summary` option to show INFO/WARNING/ERROR counts with matplotlib
- document the new option in README
- install matplotlib dependency
- test new CLI parsing and error paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ddad37848321b8f8d1a987424ec1