### PR TITLE
Add filter option to readlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--version`: Versiyon bilgisini gösterir
 - `--logfile`: Belirtilen dosyaya log kaydı başlatır
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
+- `--filter`: --readlog ile birlikte kullanıldığında, sadece verilen kelimeyi içeren satırları gösterir
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -23,6 +23,10 @@ def parse_args(args=None):
         help="Okunacak log dosyasının yolu"
     )
     parser.add_argument(
+        "--filter",
+        help="--readlog ile birlikte kullanildiginda sadece bu kelimeyi iceren satirlari goster"
+    )
+    parser.add_argument(
         "--detect-ddos",
         help="DDoS tespiti yapilacak log dosyasi"
     )
@@ -57,7 +61,10 @@ def main(argv=None):
         try:
             with open(args.readlog, encoding="utf-8") as f:
                 for line in f:
-                    if "ERROR" in line:
+                    if args.filter:
+                        if args.filter in line:
+                            print(line.rstrip("\n"))
+                    elif "ERROR" in line:
                         print(line.rstrip("\n"))
         except FileNotFoundError:
             print(f"Dosya bulunamadi: {args.readlog}", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,11 @@ def test_parse_graph_summary():
     assert args.graph_summary == "some.log"
 
 
+def test_parse_filter():
+    args = parse_args(["--filter", "first"])
+    assert args.filter == "first"
+
+
 def test_version_option(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_args(["--version"])
@@ -61,6 +66,14 @@ def test_readlog_output(capsys):
     error_lines = [line for line in captured.out.strip().splitlines() if "ERROR" in line]
     assert len(error_lines) == 2
     assert all("ERROR" in line for line in error_lines)
+
+
+def test_readlog_filter_output(capsys):
+    log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "logs", "ornek.log"))
+    main(["--readlog", log_path, "--filter", "first"])
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.strip().splitlines() if "first" in line]
+    assert len(lines) == 1
 
 
 def test_readlog_file_not_found(capsys):

--- a/tests/test_readlog.py
+++ b/tests/test_readlog.py
@@ -6,3 +6,12 @@ def test_readlog_output():
         capture_output=True, text=True
     )
     assert "ERROR" in result.stdout
+
+
+def test_readlog_filter_output_subprocess():
+    result = subprocess.run(
+        ["python3", "-m", "karsec", "--readlog", "logs/ornek.log", "--filter", "first"],
+        capture_output=True, text=True
+    )
+    assert "first" in result.stdout
+    assert "second" not in result.stdout


### PR DESCRIPTION
## Summary
- add `--filter` parameter to `karsec` CLI
- print log lines containing the given word when used with `--readlog`
- document the new option
- test parsing and behaviour of `--filter`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844deb923108321b131be603c83f89a