### PR TITLE
Add auto-mode to run all log checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 - `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak gösterir
+- `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular
 
 ## Kurulum
 ```bash
@@ -24,6 +25,7 @@ karsec --readlog logs/test.log
 karsec --detect-ddos logs/ddos.log
 karsec --summary logs/test.log
 karsec --scan-alert logs/test.log
+karsec --auto-mode logs/test.log
 Test nasıl yapılır?
 pytest tests/
 


### PR DESCRIPTION
## Summary
- add `--auto-mode` argument
- implement logic to run summary, ddos detection and scan alert sequentially
- update CLI tests and add auto-mode tests
- document new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e005b2848321bc5a46dbd00e4c80