### PR TITLE
Add log-to-elk option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 - `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak gösterir
 - `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular
+- `--log-to-elk`: Log dosyasındaki her satırı Elasticsearch sunucusuna gönderir
 
 ## Kurulum
 ```bash
@@ -26,6 +27,7 @@ karsec --detect-ddos logs/ddos.log
 karsec --summary logs/test.log
 karsec --scan-alert logs/test.log
 karsec --auto-mode logs/test.log
+karsec --log-to-elk logs/test.json
 Test nasıl yapılır?
 pytest tests/
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,11 @@ def test_parse_auto_mode():
     assert args.auto_mode == "log.log"
 
 
+def test_parse_log_to_elk():
+    args = parse_args(["--log-to-elk", "elk.log"])
+    assert args.log_to_elk == "elk.log"
+
+
 def test_parse_filter():
     args = parse_args(["--filter", "first"])
     assert args.filter == "first"
@@ -155,6 +160,14 @@ def test_scan_alert_output(capsys, tmp_path):
 def test_scan_alert_file_not_found(capsys):
     with pytest.raises(SystemExit) as exc:
         main(["--scan-alert", "yok.log"])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Dosya bulunamadi" in captured.err
+
+
+def test_log_to_elk_file_not_found(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["--log-to-elk", "missing.log"])
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "Dosya bulunamadi" in captured.err


### PR DESCRIPTION
## Summary
- allow sending log lines to Elasticsearch via `--log-to-elk`
- document new option in README
- test CLI parsing and error handling for `--log-to-elk`

## Testing
- `pip install pyfiglet matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e1dc0fa8832194a6f99e6f6034ee