### PR TITLE
Add log watching capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--version`: Versiyon bilgisini gösterir
 - `--logfile`: Belirtilen dosyaya log kaydı başlatır
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
+- `--watch`: Log dosyasına eklenen satırları anlık olarak terminale yazar
 - `--filter`: --readlog ile birlikte kullanıldığında, sadece verilen kelimeyi içeren satırları gösterir
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -5,6 +5,8 @@ import pyfiglet
 import re
 import json
 import urllib.request
+import os
+import time
 
 from . import __version__
 
@@ -23,6 +25,12 @@ def parse_args(args=None):
     parser.add_argument(
         "--readlog",
         help="Okunacak log dosyasının yolu"
+    )
+    parser.add_argument(
+        "--watch",
+        help=(
+            "Verilen log dosyasini izler ve yeni satirlari anlik olarak goster"
+        ),
     )
     parser.add_argument(
         "--filter",
@@ -67,6 +75,22 @@ def main(argv=None):
     args = parse_args(argv)
     if args.logfile:
         logging.basicConfig(filename=args.logfile, level=logging.INFO)
+    if args.watch:
+        try:
+            with open(args.watch, encoding="utf-8") as f:
+                f.seek(0, os.SEEK_END)
+                while True:
+                    line = f.readline()
+                    if line:
+                        print(line.rstrip("\n"), flush=True)
+                    else:
+                        time.sleep(0.5)
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {args.watch}", file=sys.stderr)
+            sys.exit(1)
+        except KeyboardInterrupt:
+            pass
+        return
     if args.log_to_elk:
         try:
             with open(args.log_to_elk, encoding="utf-8") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import sys
 import subprocess
 import os
+import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -18,6 +19,11 @@ def test_parse_logfile():
 def test_parse_readlog():
     args = parse_args(["--readlog", "example.log"])
     assert args.readlog == "example.log"
+
+
+def test_parse_watch():
+    args = parse_args(["--watch", "watch.log"])
+    assert args.watch == "watch.log"
 
 
 def test_parse_detect_ddos():
@@ -187,5 +193,24 @@ def test_auto_mode_output(capsys, tmp_path):
     assert "ERROR: 1" in captured.out
     assert "DDoS" in captured.out
     assert "nmap scan" in captured.out
+
+
+def test_watch_output(tmp_path):
+    log_file = tmp_path / "watch.log"
+    log_file.write_text("", encoding="utf-8")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "karsec", "--watch", str(log_file)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        time.sleep(0.5)
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write("hello\n")
+        time.sleep(0.5)
+    finally:
+        proc.terminate()
+    out, _ = proc.communicate(timeout=2)
+    assert "hello" in out
 
 


### PR DESCRIPTION
## Summary
- allow continuously watching a log file with `--watch`
- document new CLI option in README
- test `--watch` parsing and runtime behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e307ef848321a7d2285c62b6336b