### PR TITLE
Add save-summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 - `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak gösterir
+- `--save-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını JSON dosyasına yazar
 - `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular
 - `--log-to-elk`: Log dosyasındaki her satırı Elasticsearch sunucusuna gönderir
 
@@ -26,6 +27,7 @@ karsec --logfile logs/test.log
 karsec --readlog logs/test.log
 karsec --detect-ddos logs/ddos.log
 karsec --summary logs/test.log
+karsec --save-summary logs/test.log summary.json
 karsec --scan-alert logs/test.log
 karsec --auto-mode logs/test.log
 karsec --log-to-elk logs/test.json

--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -53,6 +53,13 @@ def parse_args(args=None):
         help="Log dosyasindaki INFO, WARNING ve ERROR sayilarini grafik olarak goster"
     )
     parser.add_argument(
+        "--save-summary",
+        nargs=2,
+        metavar=("LOG", "OUT"),
+        help="Verilen log dosyasindaki INFO, WARNING ve ERROR sayilarini JSON biciminde dosyaya kaydet"
+    )
+
+    parser.add_argument(
         "--auto-mode",
         help="Summary, detect-ddos ve scan-alert islemlerini tek seferde calistir"
     )
@@ -217,6 +224,25 @@ def main(argv=None):
         plt.ylabel("Adet")
         plt.tight_layout()
         plt.show()
+    if args.save_summary:
+        log_path, out_path = args.save_summary
+        summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
+        try:
+            with open(log_path, encoding="utf-8") as f:
+                for line in f:
+                    upper = line.upper()
+                    if "INFO" in upper:
+                        summary_counts["INFO"] += 1
+                    if "WARNING" in upper:
+                        summary_counts["WARNING"] += 1
+                    if "ERROR" in upper:
+                        summary_counts["ERROR"] += 1
+        except FileNotFoundError:
+            print(f"Dosya bulunamadi: {log_path}", file=sys.stderr)
+            sys.exit(1)
+        with open(out_path, "w", encoding="utf-8") as out_f:
+            json.dump(summary_counts, out_f)
+
     if args.summary:
         summary_counts = {"INFO": 0, "WARNING": 0, "ERROR": 0}
         try:


### PR DESCRIPTION
## Summary
- add `--save-summary` argument to `karsec` CLI
- write JSON summary of INFO/WARNING/ERROR counts
- document new option in README
- test new argument and logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e44df8d48321a41d43a92b6c553b