### PR TITLE
Enhance graph summary output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
-- `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak gösterir
+- `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak kaydeder
 - `--save-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını JSON dosyasına yazar
 - `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular
 - `--log-to-elk`: Log dosyasındaki her satırı Elasticsearch sunucusuna gönderir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,10 @@ def test_parse_summary():
 
 def test_parse_graph_summary():
     args = parse_args(["--graph-summary", "some.log"])
-    assert args.graph_summary == "some.log"
+    assert args.graph_summary == ["some.log"]
+
+    args = parse_args(["--graph-summary", "some.log", "out.png"])
+    assert args.graph_summary == ["some.log", "out.png"]
 
 
 def test_parse_save_summary():
@@ -145,9 +148,12 @@ def test_save_summary_file_not_found(capsys, tmp_path):
 def test_graph_summary_output(capsys, tmp_path):
     log_file = tmp_path / "graph.log"
     log_file.write_text("INFO x\nWARNING y\nERROR z\nINFO a\n", encoding="utf-8")
-    main(["--graph-summary", str(log_file)])
+    out_file = tmp_path / "out.png"
+    main(["--graph-summary", str(log_file), str(out_file)])
     captured = capsys.readouterr()
     assert captured.err == ""
+    assert out_file.exists()
+    assert "Grafik kaydedildi" in captured.out
 
 
 def test_graph_summary_file_not_found(capsys):


### PR DESCRIPTION
## Summary
- allow optional output file name for `--graph-summary`
- save matplotlib graph instead of displaying
- confirm save message, layout, and default file name
- update tests to cover new behavior
- document updated option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f1b256008321bef5a5e975f3b629