### PR TITLE
Add short options for CLI arguments

### DIFF
--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -19,37 +19,37 @@ def parse_args(args=None):
         version=f"%(prog)s {__version__}"
     )
     parser.add_argument(
-        "--logfile",
+        "-l", "--logfile",
         help="Yazılacak log dosyasının yolu"
     )
     parser.add_argument(
-        "--readlog",
+        "-r", "--readlog",
         help="Okunacak log dosyasının yolu"
     )
     parser.add_argument(
-        "--watch",
+        "-W", "--watch",
         help=(
             "Verilen log dosyasini izler ve yeni satirlari anlik olarak goster"
         ),
     )
     parser.add_argument(
-        "--filter",
+        "-f", "--filter",
         help="--readlog ile birlikte kullanildiginda sadece bu kelimeyi iceren satirlari goster"
     )
     parser.add_argument(
-        "--detect-ddos",
+        "-d", "--detect-ddos",
         help="DDoS tespiti yapilacak log dosyasi"
     )
     parser.add_argument(
-        "--summary",
+        "-s", "--summary",
         help="Log dosyasindaki INFO, WARNING ve ERROR sayilarini ozetler"
     )
     parser.add_argument(
-        "--scan-alert",
+        "-a", "--scan-alert",
         help="Log dosyasinda nmap, masscan veya nikto iceren satirlari goster"
     )
     parser.add_argument(
-        "--graph-summary",
+        "-g", "--graph-summary",
         nargs="+",
         metavar=("LOG", "OUT"),
         help=(
@@ -57,14 +57,14 @@ def parse_args(args=None):
         ),
     )
     parser.add_argument(
-        "--save-summary",
+        "-w", "--save-summary",
         nargs=2,
         metavar=("LOG", "OUT"),
         help="Verilen log dosyasindaki INFO, WARNING ve ERROR sayilarini JSON biciminde dosyaya kaydet"
     )
 
     parser.add_argument(
-        "--auto-mode",
+        "-A", "--auto-mode",
         help="Summary, detect-ddos ve scan-alert islemlerini tek seferde calistir",
     )
     parser.add_argument(
@@ -73,7 +73,7 @@ def parse_args(args=None):
         help="Otomatik islemlerin kaydedilecegi klasor (varsayilan: outputs)",
     )
     parser.add_argument(
-        "--log-to-elk",
+        "-e", "--log-to-elk",
         help="Log dosyasindaki satirlari Elasticsearch'e gonder",
     )
     return parser.parse_args(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,20 @@ def test_parse_filter():
     assert args.filter == "first"
 
 
+def test_short_option_aliases():
+    assert parse_args(["-l", "log.log"]).logfile == "log.log"
+    assert parse_args(["-r", "read.log"]).readlog == "read.log"
+    assert parse_args(["-W", "watch.log"]).watch == "watch.log"
+    assert parse_args(["-f", "term"]).filter == "term"
+    assert parse_args(["-d", "ddos.log"]).detect_ddos == "ddos.log"
+    assert parse_args(["-s", "sum.log"]).summary == "sum.log"
+    assert parse_args(["-a", "scan.log"]).scan_alert == "scan.log"
+    assert parse_args(["-g", "graph.log"]).graph_summary == ["graph.log"]
+    assert parse_args(["-w", "in.log", "out.json"]).save_summary == ["in.log", "out.json"]
+    assert parse_args(["-A", "auto.log"]).auto_mode == "auto.log"
+    assert parse_args(["-e", "elk.log"]).log_to_elk == "elk.log"
+
+
 def test_version_option(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_args(["--version"])


### PR DESCRIPTION
## Summary
- add short-form aliases for CLI arguments
- cover short options in test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f5b8f5e483219539d425b71507ce