### PR TITLE
Add questionary UI menu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         'pyfiglet',
         'matplotlib',
+        'questionary',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary
- add `questionary` dependency
- implement interactive menu with questionary when `--menu` or `--gui` flag used
- expose new run_* helpers for menu options

## Testing
- `pip install pyfiglet questionary matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845007454c483218953f920a72ddd15