### PR TITLE
Add filtered log graph feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 - `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak kaydeder
+- `--graph`: Filtrelenmiş log kayıtlarından portscan, brute-force ve dos kategorileri için bar grafik oluşturur
 - `--save-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını JSON dosyasına yazar
 - `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular. Çıktılar varsayılan olarak `outputs/` klasörüne `auto_summary.json`, `auto_ddos.txt` ve `auto_scan.txt` dosyalarına kaydedilir. `--output-dir` ile farklı klasör belirtilebilir.
 - `--log-to-elk`: Log dosyasındaki her satırı Elasticsearch sunucusuna gönderir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,11 @@ def test_parse_graph_summary():
     assert args.graph_summary == ["some.log", "out.png"]
 
 
+def test_parse_graph():
+    args = parse_args(["--graph"])
+    assert args.graph
+
+
 def test_parse_save_summary():
     args = parse_args(["--save-summary", "in.log", "out.json"])
     assert args.save_summary == ["in.log", "out.json"]
@@ -78,7 +83,7 @@ def test_short_option_aliases():
     assert parse_args(["-d", "ddos.log"]).detect_ddos == "ddos.log"
     assert parse_args(["-s", "sum.log"]).summary == "sum.log"
     assert parse_args(["-a", "scan.log"]).scan_alert == "scan.log"
-    assert parse_args(["-g", "graph.log"]).graph_summary == ["graph.log"]
+    assert parse_args(["-g"]).graph
     assert parse_args(["-w", "in.log", "out.json"]).save_summary == ["in.log", "out.json"]
     assert parse_args(["-A", "auto.log"]).auto_mode == "auto.log"
     assert parse_args(["-e", "elk.log"]).log_to_elk == "elk.log"
@@ -181,6 +186,18 @@ def test_graph_summary_file_not_found(capsys):
     assert exc.value.code == 1
     captured = capsys.readouterr()
     assert "Dosya bulunamadi" in captured.err
+
+
+def test_graph_output(tmp_path, capsys):
+    log_file = tmp_path / "graph.log"
+    log_file.write_text(
+        "attack portscan\nattack brute-force\nattack dos\n", encoding="utf-8"
+    )
+    main(["--readlog", str(log_file), "--filter", "attack", "--graph"])
+    captured = capsys.readouterr()
+    assert "Grafik kaydedildi" in captured.out
+    assert os.path.exists("graph_output.png")
+    os.remove("graph_output.png")
 
 
 def test_banner_display(capsys):


### PR DESCRIPTION
## Summary
- add new `--graph` / `-g` option for plotting filtered log categories
- generate bar graphs for `portscan`, `brute-force`, `dos`
- update README instructions
- adjust tests for new CLI option and aliases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e97993e48321bded1e6442dc723e