### PR TITLE
Refactor CLI to use global logfile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 
 ## Özellikler
 - `--version`: Versiyon bilgisini gösterir
-- `--logfile`: Belirtilen dosyaya log kaydı başlatır
+- `--logfile`: Analiz edilecek log dosyası
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
 - `--watch`: Log dosyasına eklenen satırları anlık olarak terminale yazar
 - `--filter`: --readlog ile birlikte kullanıldığında, sadece verilen kelimeyi içeren satırları gösterir
@@ -25,13 +25,12 @@ cd KarSec
 pip install .
 Nasıl kullanırım?
 karsec --version
-karsec --logfile logs/test.log
-karsec --readlog logs/test.log
-karsec --detect-ddos logs/ddos.log
-karsec --summary logs/test.log
-karsec --save-summary logs/test.log summary.json
-karsec --scan-alert logs/test.log
-karsec --auto-mode logs/test.log --output-dir results
+karsec --logfile logs/test.log --readlog
+karsec --logfile logs/test.log --detect-ddos
+karsec --logfile logs/test.log --summary
+karsec --logfile logs/test.log --save-summary summary.json
+karsec --logfile logs/test.log --scan-alert
+karsec --logfile logs/test.log --auto-mode --output-dir results
 Test nasıl yapılır?
 pytest tests/
 

--- a/tests/test_readlog.py
+++ b/tests/test_readlog.py
@@ -2,7 +2,7 @@ import subprocess
 
 def test_readlog_output():
     result = subprocess.run(
-        ["python3", "-m", "karsec", "--readlog", "logs/ornek.log"],
+        ["python3", "-m", "karsec", "--logfile", "logs/ornek.log", "--readlog"],
         capture_output=True, text=True
     )
     assert "ERROR" in result.stdout
@@ -10,7 +10,7 @@ def test_readlog_output():
 
 def test_readlog_filter_output_subprocess():
     result = subprocess.run(
-        ["python3", "-m", "karsec", "--readlog", "logs/ornek.log", "--filter", "first"],
+        ["python3", "-m", "karsec", "--logfile", "logs/ornek.log", "--readlog", "--filter", "first"],
         capture_output=True, text=True
     )
     assert "first" in result.stdout


### PR DESCRIPTION
## Summary
- refactor argument parsing so commands operate on a single `--logfile`
- update CLI logic and README usage
- adjust tests for the new argument behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684743f61f8483219aebbadc6b4db519