### PR TITLE
Add --classify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
 - `--scan-alert`: Log dosyasında nmap, masscan veya nikto içeren satırları listeler
 - `--graph-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını grafik olarak kaydeder
+- `--classify`: Anahtar kelimelere göre satırları Scan, DDoS, Brute Force ve Data Exfiltration olarak sınıflandırır
 - `--graph`: Filtrelenmiş log kayıtlarından portscan, brute-force ve dos kategorileri için bar grafik oluşturur
 - `--save-summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını JSON dosyasına yazar
 - `--auto-mode`: Tek komutla summary, detect-ddos ve scan-alert işlemlerini uygular. Çıktılar varsayılan olarak `outputs/` klasörüne `auto_summary.json`, `auto_ddos.txt` ve `auto_scan.txt` dosyalarına kaydedilir. `--output-dir` ile farklı klasör belirtilebilir.
@@ -30,6 +31,7 @@ karsec --logfile logs/test.log --detect-ddos
 karsec --logfile logs/test.log --summary
 karsec --logfile logs/test.log --save-summary summary.json
 karsec --logfile logs/test.log --scan-alert
+karsec --logfile logs/test.log --classify
 karsec --logfile logs/test.log --auto-mode --output-dir results
 Test nasıl yapılır?
 pytest tests/


### PR DESCRIPTION
## Summary
- implement `--classify` flag for grouping log lines by attack type
- document `--classify` usage in README
- test new argument parsing and output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474d756b1c8321a1c02cc71eaf2053