### PR TITLE
Implement live Suricata monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ KarSec, Linux tabanlı bir siber güvenlik aracıdır. Komut satırından çalı
 - `--logfile`: Analiz edilecek log dosyası
 - `--readlog`: Log dosyasını okuyarak "ERROR" içeren satırları gösterir
 - `--watch`: Log dosyasına eklenen satırları anlık olarak terminale yazar
+- `--live`: Suricata eve.json dosyasını canlı takip ederek olası saldırıları sınıflandırır
 - `--filter`: --readlog ile birlikte kullanıldığında, sadece verilen kelimeyi içeren satırları gösterir
 - `--detect-ddos`: Log dosyasında TCP ve SYN içeren kayıtları IP'ye göre analiz eder
 - `--summary`: Log dosyasındaki INFO, WARNING ve ERROR sayısını özetler
@@ -33,6 +34,7 @@ karsec --logfile logs/test.log --save-summary summary.json
 karsec --logfile logs/test.log --scan-alert
 karsec --logfile logs/test.log --classify
 karsec --logfile logs/test.log --auto-mode --output-dir results
+karsec --live
 Test nasıl yapılır?
 pytest tests/
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,11 @@ def test_parse_watch():
     assert args.watch
 
 
+def test_parse_live():
+    args = parse_args(["--live"])
+    assert args.live
+
+
 def test_parse_detect_ddos():
     args = parse_args(["--detect-ddos"])
     assert args.detect_ddos


### PR DESCRIPTION
## Summary
- add `--live` option to follow Suricata eve.json and classify incoming alerts
- implement live monitoring with `tail -F` parsing JSON
- document the new option in README
- test parsing of the new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847500a79688321acfe3ac1309628a7