### PR TITLE
Add PDF report generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'pyfiglet',
         'matplotlib',
         'questionary',
+        'fpdf',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary
- allow generating PDF reports via `--report`
- implement PDF generation with fpdf
- expose report option in interactive menu
- extend CLI tests for report
- include fpdf dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684753475fe88321b4b5ae88d5c0ecab