### PR TITLE
Add warning when model missing

### DIFF
--- a/karsec/cli.py
+++ b/karsec/cli.py
@@ -367,8 +367,8 @@ def load_model(model_path="model.pkl"):
         import joblib
 
         return joblib.load(model_path)
-    except Exception as e:
-        print(f"Model yuklenemedi: {e}", file=sys.stderr)
+    except Exception:
+        print("Model yuklenemedi, --predict ozelligi pasif.", file=sys.stderr)
         return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,7 +348,7 @@ def test_predict_model_missing(tmp_path, capsys):
     finally:
         os.chdir(cwd)
     captured = capsys.readouterr()
-    assert "Model yuklenemedi" in captured.err
+    assert "Model yuklenemedi, --predict ozelligi pasif." in captured.err
 
 
 def test_predict_output(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- warn when `model.pkl` cannot be loaded
- update tests for new message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475aabcad88321aa8601a4d1554ee7